### PR TITLE
add FETCH_TIMEOUT env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ ENV SELF_URL_PATH http://localhost
 ENV DB_NAME ttrss
 ENV DB_USER ttrss
 ENV DB_PASS ttrss
+ENV FETCH_TIMEOUT 60
 
 # always re-configure database with current ENV when RUNning container, then monitor all services
 ADD configure-db.php /configure-db.php

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ docker run -it --name ttrss --restart=always \
 -e DB_NAME = [ your DB name ]  \
 -e DB_USER = [ your DB user ]  \
 -e DB_PASS = [ your DB password ]  \
+-e FETCH_TIMEOUT = [ max time in seconds to fetch feeds, default 60 ] \
 -p [ your port ]:80  \
 -d wangqiru/ttrss
 ```
@@ -49,6 +50,7 @@ docker run -it --name ttrss --restart=always \
 * ENV DB_NAME
 * ENV DB_USER
 * ENV DB_PASS
+* ENV FETCH_TIMEOUT
 
 #### Deployment via docker-compose
 
@@ -100,6 +102,7 @@ docker run -it --name ttrss --restart=always \
 -e DB_NAME = [ 你的数据库名称 ]  \
 -e DB_USER = [ 你的数据库用户名 ]  \
 -e DB_PASS = [ 你的数据库密码 ]  \
+-e FETCH_TIMEOUT = [ 更新FEED的超时时间，默认60秒 ]
 -p [ 容器对外映射端口 ]:80  \
 -d wangqiru/ttrss
 ```
@@ -112,6 +115,7 @@ docker run -it --name ttrss --restart=always \
 * ENV DB_NAME
 * ENV DB_USER
 * ENV DB_PASS
+* ENV FETCH_TIMEOUT
 
 #### 通过 docker-compose 部署
 

--- a/configure-db.php
+++ b/configure-db.php
@@ -2,6 +2,7 @@
 <?php
 
 $confpath = '/var/www/config.php';
+$function_path = '/var/www/include/functions.php';
 
 $config = array();
 
@@ -12,6 +13,7 @@ $config['DB_PORT'] = env('DB_PORT', 5432);
 $config['DB_NAME'] = env('DB_NAME', 'ttrss');
 $config['DB_USER'] = env('DB_USER');
 $config['DB_PASS'] = env('DB_PASS');
+$fetch_timeout = env('FETCH_TIMEOUT',60);
 
 if(dbcheckconn($config)){
     $pdo = dbconnect($config);
@@ -46,6 +48,11 @@ if(dbcheckconn($config)){
         $contents = preg_replace('/(define\s*\(\'' . $name . '\',\s*)(.*)(\);)/', '$1"' . $value . '"$3', $contents);
     }
     file_put_contents($confpath, $contents);
+
+    $contents = file_get_contents($function_path);
+    $contents = preg_replace('/(define_default\(\'FILE_FETCH_CONNECT_TIMEOUT\',\s*)(\d+)(\);)/','${1}'.$fetch_timeout.'${3}',$contents);
+    $contents = preg_replace('/(define_default\(\'FEED_FETCH_NO_CACHE_TIMEOUT\',\s*)(\d+)(\);)/','${1}'.$fetch_timeout.'${3}',$contents);
+    file_put_contents($function_path, $contents);
 }
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - DB_NAME=ttrss
       - DB_USER=postgres
       - DB_PASS=ttrss # please change the password
+      # - FETCH_TIMEOUT=60 #optional
     stdin_open: true
     tty: true
     restart: always


### PR DESCRIPTION
默认更新RSS的连接超时时间为15秒，在更新自建RSShub的wasi或者wemp微信公众号时经常报错，所以增加配置项